### PR TITLE
Fixed error on startup

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,4 +47,4 @@ rpc.on('ready', () => {
 	}, 10e3);
 });
 
-rpc.login(ClientId).catch(console.error);
+rpc.login({ clientId: ClientId }).catch(console.error);


### PR DESCRIPTION
Error code: 4000, message: 'No Client ID Specified' was caused by an outdated method of invoking the login function. The updated API requires a format of `clientId: ClientId` rather than just `ClientId`.